### PR TITLE
Don't submit guess to server if AOCD already has correct answer

### DIFF
--- a/aocd/models.py
+++ b/aocd/models.py
@@ -252,6 +252,10 @@ class Puzzle(object):
             raise AocdError("cowardly refusing to re-submit answer_a ({}) for part b".format(value))
         url = self.submit_url
         sanitized = "..." + self.user.token[-4:]
+        check_guess = self._check_guess_against_existing(value, part)
+        if check_guess is not None: 
+            print(check_guess)
+            return
         log.info("posting %r to %s (part %s) token=%s", value, url, part, sanitized)
         level = {"a": 1, "b": 2}[part]
         response = requests.post(
@@ -308,6 +312,21 @@ class Puzzle(object):
         if not quiet:
             cprint(message, color=color)
         return response
+
+    def _check_guess_against_existing(self, guess, part):
+        try:
+            answer = self._get_answer(part=part)
+            if answer == "":
+                return None
+        except PuzzleUnsolvedError:
+            return None
+
+        if answer == guess:
+            template = "Part {part} already solved with same answer: {answer}"
+        else:
+            template = "Part {part} already solved with different answer: {answer}"
+
+        return template.format(part=part, answer=answer)
 
     def _save_correct_answer(self, value, part):
         fname = getattr(self, "answer_{}_fname".format(part))

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,3 +5,5 @@ addopts =
   --cov=aocd --cov=tests
   --cov-report=html --cov-report=term-missing:skip-covered
 requests_mock_case_sensitive = True
+markers =
+	answer_not_cached

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,3 +30,28 @@ def test_token(aocd_dir):
     token_dir.mkdir()
     token_file.write_text("thetesttoken")
     return token_file
+
+
+@pytest.fixture(autouse=True)
+def answer_not_cached(request, mocker):
+    install = True
+    rv = None
+
+    mark = request.node.get_closest_marker('answer_not_cached')
+    if mark:
+        install = mark.kwargs.get('install', True)
+        rv = mark.kwargs.get('rv', None)
+
+    if install is False: return
+
+    from aocd.models import Puzzle
+    check = mocker.patch.object(Puzzle, '_check_guess_against_existing')
+    check.return_value = rv
+    return check
+
+
+@pytest.fixture
+def get_answer(mocker):
+    from aocd.models import Puzzle
+    answer = mocker.patch.object(Puzzle, '_get_answer')
+    return answer

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -279,3 +279,42 @@ def test_get_stats_400(requests_mock):
     user = User("testtoken")
     with pytest.raises(HTTPError):
         user.get_stats()
+
+
+@pytest.mark.answer_not_cached(install=False)
+def test_check_guess_against_unsolved(get_answer):
+    get_answer.side_effect=PuzzleUnsolvedError("")
+
+    puzzle = Puzzle(year=2019, day=4)
+    rv = puzzle._check_guess_against_existing("one", "a")
+
+    assert rv is None
+
+
+@pytest.mark.answer_not_cached(install=False)
+def test_check_guess_against_empty(get_answer):
+    get_answer.return_value = ""
+
+    puzzle = Puzzle(year=2019, day=4)
+    rv = puzzle._check_guess_against_existing("one", "a")
+
+    assert rv is None
+
+
+@pytest.mark.answer_not_cached(install=False)
+def test_check_guess_against_saved_correct(get_answer):
+    get_answer.return_value = "one"
+
+    puzzle = Puzzle(year=2019, day=4)
+    rv = puzzle._check_guess_against_existing("one", "a")
+
+    assert rv == "Part a already solved with same answer: one"
+
+@pytest.mark.answer_not_cached(install=False)
+def test_check_guess_against_saved_incorrect(get_answer):
+    get_answer.return_value = "two"
+
+    puzzle = Puzzle(year=2019, day=4)
+    rv = puzzle._check_guess_against_existing("one", "a")
+
+    assert rv == "Part a already solved with different answer: two"

--- a/tests/test_submit.py
+++ b/tests/test_submit.py
@@ -249,3 +249,13 @@ def test_cannot_submit_same_bad_answer_twice(requests_mock, capsys):
 def test_will_not_submit_null():
     with pytest.raises(AocdError("cowardly refusing to submit non-answer: None")):
         submit(None, part="a")
+
+
+@pytest.mark.answer_not_cached(rv='value')
+def test_submit_guess_against_saved(requests_mock, capsys):
+    post = requests_mock.post(
+        url="https://adventofcode.com/2018/day/1/answer",
+        text="<article>That's the right answer. Yeah!!</article>",
+    )
+    submit(1234, part="a", day=1, year=2018, session="whatever", reopen=False)
+    assert post.call_count == 0


### PR DESCRIPTION
Previously, AOCD would send the guess to AOC servers and you'd get
warning/error of "You don't seem to be solving the right level.
Did you already complete it? [Return to Day xxxx]"

This happens for me if I'm re-working the solution after I've solved
things in a quick-n-dirty manner. With this change you'll get
potentially two different messages:
- "Part xxxx already solved with same answer: yyyyy"
- "Part xxxx already solved with different answer: yyyyy"
and the submit won't hit the servers again.