### PR TITLE
Adding AOCD_CONFIG_DIR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,8 +69,10 @@ your browser inspector.  If you're hacking on AoC at all you probably already
 know these kind of tricks, but if you need help with that part then you can
 `look here <https://github.com/wimglenn/advent-of-code/issues/1>`_.
 
-*Note:* If you don't like the env var, you could also put into a text file
-in your home directory (use the filename ``~/.config/aocd/token``).
+*Note:* If you don't like the env var, you could also put your token(s) into a
+text file. By default this is ``~/.config/aocd/token`` or
+``~/.config/aocd/tokens.json``. You can change the directory of these files by
+setting the ``AOCD_CONFIG_DIR`` environment variable.
 
 *New in version 0.9.0.* There's a utility script ``aocd-token`` which attempts to
 find session tokens from your browser's cookie storage. This feature is experimental
@@ -203,3 +205,9 @@ All data is persisted in plain text files under ``~/.config/aocd``. To remove an
 caches, you may simply delete whatever files you want under that directory tree.
 If you'd prefer to use a different path, then export an ``AOCD_DIR`` environment
 variable with the desired location.
+
+By default, your token files are also stored in ``~/.config/aocd``, if the
+``AOCD_DIR`` environment variable is set, this supercedes this path. To allow
+configuration and the cache to exist in separate locations, you can use the
+the environment variable ``AOCD_CONFIG_DIR`` to set the location of your ``token``
+or ``tokens.json`` file.

--- a/aocd/cookies.py
+++ b/aocd/cookies.py
@@ -6,7 +6,7 @@ import os
 import sys
 
 from aocd.exceptions import DeadTokenError
-from aocd.models import AOCD_DIR
+from aocd.models import AOCD_CONFIG_DIR
 from aocd.utils import _ensure_intermediate_dirs
 from aocd.utils import get_owner
 
@@ -15,8 +15,8 @@ log = logging.getLogger(__name__)
 
 
 def scrape_session_tokens():
-    aocd_token_file = os.path.join(AOCD_DIR, "token")
-    aocd_tokens_file = os.path.join(AOCD_DIR, "tokens.json")
+    aocd_token_file = os.path.join(AOCD_CONFIG_DIR, "token")
+    aocd_tokens_file = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
 
     parser = argparse.ArgumentParser(description="Scrapes AoC session tokens from your browser's cookie storage")
     parser.add_argument("-v", "--verbose", action="count", help="increased logging (may be specified multiple)")

--- a/aocd/models.py
+++ b/aocd/models.py
@@ -526,11 +526,3 @@ def _parse_duration(s):
     return timedelta(hours=h, minutes=m, seconds=s)
 
 
-def load_users():
-    path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
-    try:
-        with open(path) as f:
-            users = json.load(f)
-    except IOError:
-        users = {"default": default_user().token}
-    return users

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -53,7 +53,6 @@ def main():
     parser.add_argument("--log-level", default="WARNING", choices=log_levels)
     args = parser.parse_args()
 
-    print('USERS', users)
     if not users:
         path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
         print(

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import itertools
+import json
 import logging
 import os
 import sys
@@ -16,10 +17,11 @@ from datetime import datetime
 
 import pebble.concurrent
 import pkg_resources
+from models import AOCD_CONFIG_DIR, default_user
 from termcolor import colored
 
 from .exceptions import AocdError
-from .models import AOCD_CONFIG_DIR, load_users
+from .models import AOCD_CONFIG_DIR
 from .models import Puzzle
 from .utils import AOC_TZ
 
@@ -39,7 +41,7 @@ def main():
     years = range(2015, aoc_now.year + int(aoc_now.month == 12))
     days = range(1, 26)
 
-    users = load_users()
+    users = _load_users()
 
     log_levels = "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
     parser = ArgumentParser(description="AoC runner")
@@ -230,3 +232,13 @@ def run_for(plugins, years, days, datasets, timeout=DEFAULT_TIMEOUT, autosubmit=
                 line += result_template.format(icon=icon, part=part, answer=answer)
         print(line)
     return n_incorrect
+
+
+def _load_users():
+    path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
+    try:
+        with open(path) as f:
+            users = json.load(f)
+    except IOError:
+        users = {"default": default_user().token}
+    return users

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import itertools
-import json
 import logging
 import os
 import sys
@@ -20,8 +19,7 @@ import pkg_resources
 from termcolor import colored
 
 from .exceptions import AocdError
-from .models import AOCD_DIR
-from .models import default_user
+from .models import AOCD_CONFIG_DIR, load_users
 from .models import Puzzle
 from .utils import AOC_TZ
 
@@ -40,12 +38,9 @@ def main():
     aoc_now = datetime.now(tz=AOC_TZ)
     years = range(2015, aoc_now.year + int(aoc_now.month == 12))
     days = range(1, 26)
-    path = os.path.join(AOCD_DIR, "tokens.json")
-    try:
-        with open(path) as f:
-            users = json.load(f)
-    except IOError:
-        users = {"default": default_user().token}
+
+    users = load_users()
+
     log_levels = "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"
     parser = ArgumentParser(description="AoC runner")
     parser.add_argument("-p", "--plugins", choices=plugins)
@@ -57,7 +52,10 @@ def main():
     parser.add_argument("-r", "--reopen", action="store_true", help="open browser on NEW solves")
     parser.add_argument("--log-level", default="WARNING", choices=log_levels)
     args = parser.parse_args()
+
+    print('USERS', users)
     if not users:
+        path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
         print(
             "There are no datasets available to use.\n"
             "Either export your AOC_SESSION or put some auth "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,24 +12,32 @@ def mocked_sleep(mocker):
 
 
 @pytest.fixture
-def aocd_dir(tmp_path):
-    data_dir = tmp_path / ".config" / "aocd"
+def aocd_data_dir(tmp_path):
+    data_dir = tmp_path / ".config" / "aocd-data"
+    data_dir.mkdir(parents=True)
+    return data_dir
+
+
+@pytest.fixture
+def aocd_config_dir(tmp_path):
+    data_dir = tmp_path / ".config" / "aocd-config"
     data_dir.mkdir(parents=True)
     return data_dir
 
 
 @pytest.fixture(autouse=True)
-def remove_user_env(aocd_dir, monkeypatch):
-    monkeypatch.setattr("aocd.runner.AOCD_DIR", str(aocd_dir))
-    monkeypatch.setattr("aocd.models.AOCD_DIR", str(aocd_dir))
-    monkeypatch.setattr("aocd.cookies.AOCD_DIR", str(aocd_dir))
+def remove_user_env(aocd_data_dir, monkeypatch, aocd_config_dir):
+    monkeypatch.setattr("aocd.runner.AOCD_CONFIG_DIR", str(aocd_config_dir))
+    monkeypatch.setattr("aocd.models.AOCD_DATA_DIR", str(aocd_data_dir))
+    monkeypatch.setattr("aocd.models.AOCD_CONFIG_DIR", str(aocd_config_dir))
+    monkeypatch.setattr("aocd.cookies.AOCD_CONFIG_DIR", str(aocd_config_dir))
     monkeypatch.delenv(str("AOC_SESSION"), raising=False)
 
 
 @pytest.fixture(autouse=True)
-def test_token(aocd_dir):
-    token_file = aocd_dir / "token"
-    cache_dir = aocd_dir / "testauth.testuser.000"
+def test_token(aocd_config_dir, aocd_data_dir):
+    token_file = aocd_config_dir / "token"
+    cache_dir = aocd_data_dir / "testauth.testuser.000"
     cache_dir.mkdir()
     token_file.write_text("thetesttoken")
     return token_file

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -37,7 +37,7 @@ def test_saved_data_is_reused_if_available(aocd_data_dir, requests_mock):
     )
     cached = aocd_data_dir / "testauth.testuser.000/2018_01_input.txt"
     cached.touch()
-    cached.write_text("saved data for year 2018 day 1")
+    cached.write_text(u"saved data for year 2018 day 1")
     data = aocd.get_data(year=2018, day=1)
     assert data == "saved data for year 2018 day 1"
     assert not mock.called

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -30,14 +30,14 @@ def test_get_data_uses_current_date_if_unspecified(requests_mock, freezer):
     assert mock.call_count == 1
 
 
-def test_saved_data_is_reused_if_available(tmpdir, requests_mock):
+def test_saved_data_is_reused_if_available(aocd_data_dir, requests_mock):
     mock = requests_mock.get(
         url="https://adventofcode.com/2018/day/1/input",
         text="fake data for year 2018 day 1",
     )
-    cached = tmpdir / ".config/aocd/testauth.testuser.000/2018_01_input.txt"
-    cached.ensure(file=True)
-    cached.write("saved data for year 2018 day 1")
+    cached = aocd_data_dir / "testauth.testuser.000/2018_01_input.txt"
+    cached.touch()
+    cached.write_text("saved data for year 2018 day 1")
     data = aocd.get_data(year=2018, day=1)
     assert data == "saved data for year 2018 day 1"
     assert not mock.called
@@ -102,20 +102,20 @@ def test_aocd_user_agent_in_req_headers(requests_mock):
     assert headers["User-Agent"] == expected
 
 
-def test_data_is_cached_from_successful_request(tmpdir, requests_mock):
+def test_data_is_cached_from_successful_request(aocd_data_dir, requests_mock):
     requests_mock.get(
         url="https://adventofcode.com/2018/day/1/input",
         text="fake data for year 2018 day 1",
     )
-    cached = tmpdir / ".config/aocd/testauth.testuser.000/2018_01_input.txt"
+    cached = aocd_data_dir / "testauth.testuser.000/2018_01_input.txt"
     assert not cached.exists()
     aocd.get_data(year=2018, day=1)
     assert cached.exists()
-    assert cached.read() == "fake data for year 2018 day 1"
+    assert cached.read_text() == "fake data for year 2018 day 1"
 
 
-def test_corrupted_cache(tmpdir):
-    cached = tmpdir / ".config/aocd/testauth.testuser.000/2018_01_input.txt"
-    cached.ensure_dir()
+def test_corrupted_cache(aocd_data_dir):
+    cached = aocd_data_dir / "testauth.testuser.000/2018_01_input.txt"
+    cached.mkdir(parents=True)
     with pytest.raises(IOError):
         aocd.get_data(year=2018, day=1)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,40 +13,40 @@ from aocd.models import Puzzle
 from aocd.models import User
 
 
-def test_get_answer(aocd_dir):
-    saved = aocd_dir / "testauth.testuser.000" / "2017_13b_answer.txt"
+def test_get_answer(aocd_data_dir):
+    saved = aocd_data_dir / "testauth.testuser.000" / "2017_13b_answer.txt"
     saved.write_text("the answer")
     puzzle = Puzzle(day=13, year=2017)
     assert puzzle.answer_b == "the answer"
 
 
-def test_get_answer_not_existing(aocd_dir, requests_mock):
+def test_get_answer_not_existing(aocd_data_dir, requests_mock):
     requests_mock.get("https://adventofcode.com/2017/day/13")
     puzzle = Puzzle(day=13, year=2017)
     with pytest.raises(AttributeError("answer_b")):
         puzzle.answer_b
 
 
-def test_get_answer_not_existing_ok_on_25dec(aocd_dir, requests_mock):
-    answer_path = aocd_dir / "testauth.testuser.000" / "2017_25a_answer.txt"
+def test_get_answer_not_existing_ok_on_25dec(aocd_data_dir):
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2017_25a_answer.txt"
     answer_path.write_text("yeah")
     puzzle = Puzzle(day=25, year=2017)
     assert not puzzle.answer_b
     assert puzzle.answers == ("yeah", "")
 
 
-def test_both_puzzle_answers_tuple(aocd_dir):
-    answer_a_path = aocd_dir / "testauth.testuser.000" / "2016_06a_answer.txt"
-    answer_b_path = aocd_dir / "testauth.testuser.000" / "2016_06b_answer.txt"
+def test_both_puzzle_answers_tuple(aocd_data_dir):
+    answer_a_path = aocd_data_dir / "testauth.testuser.000" / "2016_06a_answer.txt"
+    answer_b_path = aocd_data_dir / "testauth.testuser.000" / "2016_06b_answer.txt"
     answer_a_path.write_text("1234")
     answer_b_path.write_text("wxyz")
     puzzle = Puzzle(year=2016, day=6)
     assert puzzle.answers == ("1234", "wxyz")
 
 
-def test_answered(aocd_dir):
-    answer_a_path = aocd_dir / "testauth.testuser.000" / "2016_07a_answer.txt"
-    answer_b_path = aocd_dir / "testauth.testuser.000" / "2016_07b_answer.txt"
+def test_answered(aocd_data_dir):
+    answer_a_path = aocd_data_dir / "testauth.testuser.000" / "2016_07a_answer.txt"
+    answer_b_path = aocd_data_dir / "testauth.testuser.000" / "2016_07b_answer.txt"
     puzzle = Puzzle(year=2016, day=7)
     answer_a_path.write_text("foo")
     answer_b_path.write_text("")
@@ -70,8 +70,8 @@ def test_setattr_submits(mocker, requests_mock):
     mock.assert_called_once_with(part="a", value="4321")
 
 
-def test_setattr_doesnt_submit_if_already_done(mocker, aocd_dir):
-    answer_path = aocd_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
+def test_setattr_doesnt_submit_if_already_done(mocker, aocd_data_dir):
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
     answer_path.write_text("someval")
     puzzle = Puzzle(year=2017, day=7)
     mock = mocker.patch("aocd.models.Puzzle._submit")
@@ -79,9 +79,9 @@ def test_setattr_doesnt_submit_if_already_done(mocker, aocd_dir):
     mock.assert_not_called()
 
 
-def test_setattr_submit_both(aocd_dir, mocker, requests_mock):
+def test_setattr_submit_both(aocd_data_dir, mocker, requests_mock):
     requests_mock.get("https://adventofcode.com/2017/day/7")
-    answer_path = aocd_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
     answer_path.write_text("4321")
     puzzle = Puzzle(year=2017, day=7)
     mock = mocker.patch("aocd.models.Puzzle._submit")
@@ -89,9 +89,9 @@ def test_setattr_submit_both(aocd_dir, mocker, requests_mock):
     mock.assert_called_once_with(part="b", value="zyxw")
 
 
-def test_setattr_doesnt_submit_both_if_done(mocker, aocd_dir):
-    answer_a_path = aocd_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
-    answer_b_path = aocd_dir / "testauth.testuser.000" / "2017_07b_answer.txt"
+def test_setattr_doesnt_submit_both_if_done(mocker, aocd_data_dir):
+    answer_a_path = aocd_data_dir / "testauth.testuser.000" / "2017_07a_answer.txt"
+    answer_b_path = aocd_data_dir / "testauth.testuser.000" / "2017_07b_answer.txt"
     answer_a_path.write_text("ansA")
     answer_b_path.write_text("321")
     puzzle = Puzzle(year=2017, day=7)
@@ -109,8 +109,8 @@ def test_solve_no_plugs(mocker):
     mock.assert_called_once_with(group="adventofcode.user")
 
 
-def test_solve_one_plug(aocd_dir, mocker):
-    input_path = aocd_dir / "testauth.testuser.000" / "2018_01_input.txt"
+def test_solve_one_plug(aocd_data_dir, mocker):
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2018_01_input.txt"
     input_path.write_text("someinput")
     ep = mocker.Mock()
     ep.name = "myplugin"
@@ -120,8 +120,8 @@ def test_solve_one_plug(aocd_dir, mocker):
     ep.load.return_value.assert_called_once_with(year=2018, day=1, data="someinput")
 
 
-def test_solve_for(aocd_dir, mocker):
-    input_path = aocd_dir / "testauth.testuser.000" / "2018_01_input.txt"
+def test_solve_for(aocd_data_dir, mocker):
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2018_01_input.txt"
     input_path.write_text("blah")
     plug1 = mocker.Mock()
     plug1.name = "myplugin"
@@ -136,8 +136,8 @@ def test_solve_for(aocd_dir, mocker):
     plug2.load.return_value.assert_not_called()
 
 
-def test_solve_for_unfound_user(aocd_dir, mocker):
-    input_path = aocd_dir / "testauth.testuser.000" / "2018_01_input.txt"
+def test_solve_for_unfound_user(aocd_data_dir, mocker):
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2018_01_input.txt"
     input_path.write_text("someinput")
     other_plug = mocker.Mock()
     other_plug.name = "otherplugin"
@@ -331,8 +331,8 @@ def test_check_guess_against_saved_incorrect(mocker):
     assert "Part a already solved with different answer: two" in rv
 
 
-def test_owner_cache(aocd_dir):
-    cache = aocd_dir / "token2id.json"
+def test_owner_cache(aocd_data_dir):
+    cache = aocd_data_dir / "token2id.json"
     cache.write_text('{"bleh": "a.u.n"}')
     user = User(token="bleh")
     user_id = user.id

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -27,8 +27,8 @@ def test_no_plugins_avail(capsys, mocker):
     mock.assert_called_once_with(group="adventofcode.user")
 
 
-def test_no_datasets_avail(capsys, mocker, aocd_dir):
-    datasets_file = aocd_dir / "tokens.json"
+def test_no_datasets_avail(capsys, mocker, aocd_config_dir):
+    datasets_file = aocd_config_dir / "tokens.json"
     datasets_file.write_text("{}")
     mocker.patch("sys.argv", ["aoc"])
     msg = (
@@ -43,14 +43,14 @@ def test_no_datasets_avail(capsys, mocker, aocd_dir):
     assert msg in err
 
 
-def test_main(capsys, mocker, aocd_dir):
+def test_main(capsys, mocker, aocd_config_dir):
     mock = mocker.patch("aocd.runner.run_for", return_value=0)
     ep1 = mocker.Mock()
     ep1.name = "user1"
     ep2 = mocker.Mock()
     ep2.name = "user2"
     mocker.patch("pkg_resources.iter_entry_points", return_value=iter([ep1, ep2]))
-    datasets_file = aocd_dir / "tokens.json"
+    datasets_file = aocd_config_dir / "tokens.json"
     datasets_file.write_text('{"data1": "token1", "data2": "token2"}')
     mocker.patch("sys.argv", ["aoc", "--years=2015", "--days", "3", "7"])
     with pytest.raises(SystemExit(0)):
@@ -175,14 +175,14 @@ def test_day_out_of_range(mocker, capsys, freezer):
     assert out == err == ""
 
 
-def test_run_error(aocd_dir, mocker, capsys):
-    title_path = aocd_dir / "titles"
+def test_run_error(aocd_data_dir, mocker, capsys):
+    title_path = aocd_data_dir / "titles"
     title_path.mkdir()
     title_file = title_path / "2018_25.txt"
     title_file.write_text("The Puzzle Title")
-    input_path = aocd_dir / "testauth.testuser.000" / "2018_25_input.txt"
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2018_25_input.txt"
     input_path.write_text("someinput")
-    answer_path = aocd_dir / "testauth.testuser.000" / "2018_25a_answer.txt"
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2018_25a_answer.txt"
     answer_path.write_text("answ")
     ep = mocker.Mock()
     ep.name = "testuser"
@@ -201,14 +201,14 @@ def test_run_error(aocd_dir, mocker, capsys):
     assert "part b" not in out  # because it's 25 dec, no part b puzzle
 
 
-def test_run_and_autosubmit(aocd_dir, mocker, capsys, requests_mock):
-    title_path = aocd_dir / "titles"
+def test_run_and_autosubmit(aocd_data_dir, mocker, capsys, requests_mock):
+    title_path = aocd_data_dir / "titles"
     title_path.mkdir()
     title_file = title_path / "2015_01.txt"
     title_file.write_text("The Puzzle Title")
-    input_path = aocd_dir / "testauth.testuser.000" / "2015_01_input.txt"
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2015_01_input.txt"
     input_path.write_text("testinput")
-    answer_path = aocd_dir / "testauth.testuser.000" / "2015_01a_answer.txt"
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2015_01a_answer.txt"
     answer_path.write_text("answer1")
     requests_mock.get(url="https://adventofcode.com/2015/day/1")
     requests_mock.post(
@@ -230,14 +230,14 @@ def test_run_and_autosubmit(aocd_dir, mocker, capsys, requests_mock):
     assert "part b: wrong (correct answer unknown)" in out
 
 
-def test_run_and_no_autosubmit(aocd_dir, mocker, capsys, requests_mock):
-    title_path = aocd_dir / "titles"
+def test_run_and_no_autosubmit(aocd_data_dir, mocker, capsys, requests_mock):
+    title_path = aocd_data_dir / "titles"
     title_path.mkdir()
     title_file = title_path / "2015_01.txt"
     title_file.write_text("The Puzzle Title")
-    input_path = aocd_dir / "testauth.testuser.000" / "2015_01_input.txt"
+    input_path = aocd_data_dir / "testauth.testuser.000" / "2015_01_input.txt"
     input_path.write_text("testinput")
-    answer_path = aocd_dir / "testauth.testuser.000" / "2015_01a_answer.txt"
+    answer_path = aocd_data_dir / "testauth.testuser.000" / "2015_01a_answer.txt"
     answer_path.write_text("answer1")
     requests_mock.get(url="https://adventofcode.com/2015/day/1")
     ep = mocker.Mock()


### PR DESCRIPTION
This is to address #55.

It adds a new env variable `AOCD_CONFIG_DIR`. 
If this is unset, behaviour defaults to using `AOCD_DIR`.

Have a look and let me know if any changes are needed.