### PR TITLE
add --user option to aocd + autocomplete choices

### DIFF
--- a/aocd/models.py
+++ b/aocd/models.py
@@ -544,3 +544,13 @@ def _parse_duration(s):
         return timedelta(hours=24)
     h, m, s = [int(x) for x in s.split(":")]
     return timedelta(hours=h, minutes=m, seconds=s)
+
+
+def _load_users():
+    path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
+    try:
+        with open(path) as f:
+            users = json.load(f)
+    except IOError:
+        users = {"default": default_user().token}
+    return users

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import itertools
-import json
 import logging
 import os
 import sys
@@ -17,13 +16,15 @@ from datetime import datetime
 
 import pebble.concurrent
 import pkg_resources
+from functools import partial
 from termcolor import colored
 
 from .exceptions import AocdError
 from .models import AOCD_CONFIG_DIR
-from .models import default_user
+from .models import _load_users
 from .models import Puzzle
 from .utils import AOC_TZ
+from .utils import _cli_guess
 
 
 # from https://adventofcode.com/about
@@ -46,7 +47,7 @@ def main():
     parser.add_argument("-p", "--plugins", nargs="+", choices=plugins)
     parser.add_argument("-y", "--years", type=int, nargs="+", choices=years)
     parser.add_argument("-d", "--days", type=int, nargs="+", choices=days)
-    parser.add_argument("-u", "--users", nargs="+", choices=users)
+    parser.add_argument("-u", "--users", nargs="+", choices=users, type=partial(_cli_guess, choices=users))
     parser.add_argument("-t", "--timeout", type=int, default=DEFAULT_TIMEOUT)
     parser.add_argument("-s", "--no-submit", action="store_true", help="disable autosubmit")
     parser.add_argument("-r", "--reopen", action="store_true", help="open browser on NEW solves")
@@ -249,13 +250,3 @@ def run_for(plugins, years, days, datasets, timeout=DEFAULT_TIMEOUT, autosubmit=
                 line += result_template.format(icon=icon, part=part, answer=answer)
         print(line)
     return n_incorrect
-
-
-def _load_users():
-    path = os.path.join(AOCD_CONFIG_DIR, "tokens.json")
-    try:
-        with open(path) as f:
-            users = json.load(f)
-    except IOError:
-        users = {"default": default_user().token}
-    return users

--- a/aocd/utils.py
+++ b/aocd/utils.py
@@ -119,6 +119,6 @@ def _cli_guess(choice, choices):
     if len(candidates) > 1:
         raise argparse.ArgumentTypeError("{} ambiguous (could be {})".format(choice, ", ".join(candidates)))
     elif not candidates:
-        raise argparse.ArgumentTypeError("invalid choice: {!r} (choose from {})".format(choice, ", ".join(choices)))
+        raise argparse.ArgumentTypeError("invalid choice {!r} (choose from {})".format(choice, ", ".join(choices)))
     [result] = candidates
     return result

--- a/aocd/utils.py
+++ b/aocd/utils.py
@@ -1,3 +1,4 @@
+import argparse
 import bs4
 import errno
 import logging
@@ -108,4 +109,16 @@ def get_owner(token):
                 username = span.text
                 break
     result = ".".join([auth_source, username, userid])
+    return result
+
+
+def _cli_guess(choice, choices):
+    if choice in choices:
+        return choice
+    candidates = [c for c in choices if choice in c]
+    if len(candidates) > 1:
+        raise argparse.ArgumentTypeError("{} ambiguous (could be {})".format(choice, ", ".join(candidates)))
+    elif not candidates:
+        raise argparse.ArgumentTypeError("invalid choice: {!r} (choose from {})".format(choice, ", ".join(choices)))
+    [result] = candidates
     return result

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -54,3 +54,28 @@ def test_main_user_ambiguous(mocker, capsys):
         main()
     out, err = capsys.readouterr()
     assert "aocd: error: argument -u/--user: y ambiguous (could be billy, teddy)" in err
+
+
+def test_main_user_exact(mocker, capsys):
+    fake_users = {
+        "bill": "b",
+        "billy": "b2",
+    }
+    mocker.patch("aocd.cli._load_users", return_value=fake_users)
+    mocker.patch("sys.argv", ["aocd", "2015", "8", "-u", "bill"])
+    getter = mocker.patch("aocd.cli.get_data", return_value="stuff")
+    main()
+    getter.assert_called_once_with(session="b", year=2015, day=8)
+
+
+def test_main_user_wat(mocker, capsys):
+    fake_users = {
+        "bill": "b",
+        "teddy": "t",
+    }
+    mocker.patch("aocd.cli._load_users", return_value=fake_users)
+    mocker.patch("sys.argv", ["aocd", "2015", "8", "-u", "z"])
+    with pytest.raises(SystemExit(2)):
+        main()
+    out, err = capsys.readouterr()
+    assert "aocd: error: argument -u/--user: invalid choice 'z' (choose from bill, teddy)" in err

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ def test_main_valid_date(mocker, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out == "stuff\n"
-    getter.assert_called_once_with(year=2015, day=8)
+    getter.assert_called_once_with(session=None, year=2015, day=8)
 
 
 def test_main_valid_date_forgiving(mocker, capsys):
@@ -28,4 +28,29 @@ def test_main_valid_date_forgiving(mocker, capsys):
     out, err = capsys.readouterr()
     assert err == ""
     assert out == "stuff\n"
-    getter.assert_called_once_with(year=2015, day=8)
+    getter.assert_called_once_with(session=None, year=2015, day=8)
+
+
+def test_main_user_guess(mocker, capsys):
+    fake_users = {
+        "bill": "b",
+        "teddy": "t",
+    }
+    mocker.patch("aocd.cli._load_users", return_value=fake_users)
+    mocker.patch("sys.argv", ["aocd", "2015", "8", "-u", "ted"])
+    getter = mocker.patch("aocd.cli.get_data", return_value="stuff")
+    main()
+    getter.assert_called_once_with(session="t", year=2015, day=8)
+
+
+def test_main_user_ambiguous(mocker, capsys):
+    fake_users = {
+        "billy": "b",
+        "teddy": "t",
+    }
+    mocker.patch("aocd.cli._load_users", return_value=fake_users)
+    mocker.patch("sys.argv", ["aocd", "2015", "8", "-u", "y"])
+    with pytest.raises(SystemExit(2)):
+        main()
+    out, err = capsys.readouterr()
+    assert "aocd: error: argument -u/--user: y ambiguous (could be billy, teddy)" in err


### PR DESCRIPTION
allows aocd to be called with --user option (choices taken from `~/.config/aocd/tokens.json`).  aoc and aocd can also now guess the user if the argument was uniquely a substring of one of the choices

i.e. you can use `aoc -u goog` as shorthand for `aoc -u google.username.123456` or whatever