### PR TITLE
Make `data` discoverable by static analysers

### DIFF
--- a/aocd/__init__.py
+++ b/aocd/__init__.py
@@ -47,8 +47,8 @@ __all__ = [
 ]
 __all__ += transforms.__all__
 
-# Add type annotations for magic attribute `data` to make it discoverable by static analysis tools.
-data: str
+# Add declaration for magic attribute `data` to make it discoverable by static analysis tools.
+data = ""
 
 
 class Aocd(object):

--- a/aocd/__init__.py
+++ b/aocd/__init__.py
@@ -47,6 +47,9 @@ __all__ = [
 ]
 __all__ += transforms.__all__
 
+# Add type annotations for magic attribute `data` to make it discoverable by static analysis tools.
+data: str
+
 
 class Aocd(object):
     _module = sys.modules[__name__]


### PR DESCRIPTION
Various IDEs have trouble understanding the "magic" `data` object used in the prototypical use of this package:

![image](https://user-images.githubusercontent.com/8997458/147606468-b95c9220-7ff5-4fe8-b47c-a3771ce96532.png)

This example is from NeoVim using [pyright](https://github.com/microsoft/pyright), but the same thing happens in PyCharm and probably in any similar tool. Looking at `aocd/__init__.py` the reason is clear - `data` is not declared as a variable. I understand _why_ this is, so I'm not proposing to change any of the import logic. After all, it _works at runtime_, so this is just about helping out pedantic nitpickers like myself who find this "error" annoying to look at. 

It is enough to just declare `data` using a type declaration, which should have no further implications or impact on anything else. Additionally, it helps tools like [mypy](http://mypy-lang.org/), by letting them know that it will always be a string. 

I've tested this in all the IDEs I have at hand, and it works as advertised. 

In this PR I've placed the annotation where I thought it looked best and added a comment, but please rearrange at will.