### PR TITLE
pytest-freezegun is causing DeprecationWarning on 3.11, switch to pyt…

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,6 +3,6 @@ pytest
 pytest-cov
 pytest-mock
 pytest-raisin
-pytest-freezegun
+pytest-freezer
 pytest-socket
 requests-mock


### PR DESCRIPTION
…est-freezer instead