### PR TITLE
Fix race condition between write and query of cached data

### DIFF
--- a/aocd/get.py
+++ b/aocd/get.py
@@ -22,7 +22,7 @@ from .utils import blocker
 log = getLogger(__name__)
 
 
-def get_data(session=None, day=None, year=None, block=False):
+def get_data(session=None, day=None, year=None, block=False, example=False):
     """
     Get data for day (1-25) and year (>= 2015)
     User's session cookie is needed (puzzle inputs differ by user)

--- a/aocd/get.py
+++ b/aocd/get.py
@@ -22,7 +22,7 @@ from .utils import blocker
 log = getLogger(__name__)
 
 
-def get_data(session=None, day=None, year=None, block=False, example=False):
+def get_data(session=None, day=None, year=None, block=False):
     """
     Get data for day (1-25) and year (>= 2015)
     User's session cookie is needed (puzzle inputs differ by user)

--- a/aocd/models.py
+++ b/aocd/models.py
@@ -240,6 +240,7 @@ class Puzzle(object):
         except Exception:
             log.info("unable to find example data year=%s day=%s", self.year, self.day)
             data = ""
+        log.info("saving the example data")
         atomic_write_file(self.example_input_data_fname, data)
         return data.rstrip("\r\n")
 

--- a/aocd/models.py
+++ b/aocd/models.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import sys
+import tempfile
 import time
 import webbrowser
 from datetime import datetime
@@ -219,9 +220,17 @@ class Puzzle(object):
             raise AocdError("Unexpected response")
         data = response.text
         _ensure_intermediate_dirs(self.input_data_fname)
-        with open(self.input_data_fname, "w") as f:
-            log.info("saving the puzzle input token=%s", sanitized)
+        with tempfile.NamedTemporaryFile(
+                mode='w', dir=os.path.dirname(self.input_data_fname), delete=False) as f:
+            tmp_name = f.name
+            log.info("saving the puzzle input token=%s to %s", sanitized, tmp_name)
             f.write(data)
+        try:
+            os.rename(tmp_name, self.input_data_fname)
+        except FileExistsError:
+            log.warning("example data at %s already exists; deleting temporary %s",
+                    self.input_data_fname, tmp_name)
+            os.unlink(tmp_name)
         return data.rstrip("\r\n")
 
     @property
@@ -241,9 +250,17 @@ class Puzzle(object):
         except Exception:
             log.info("unable to find example data year=%s day=%s", self.year, self.day)
             data = ""
-        with open(self.example_input_data_fname, "w") as f:
-            log.info("saving the example data")
+        with tempfile.NamedTemporaryFile(
+                mode='w', dir=os.path.dirname(self.example_input_data_fname), delete=False) as f:
+            tmp_name = f.name
+            log.info("saving the example data to %s", tmp_name)
             f.write(data)
+        try:
+            os.rename(tmp_name, self.example_input_data_fname)
+        except FileExistsError:
+            log.warning("example data at %s already exists; deleting temporary %s",
+                    self.example_input_data_fname, tmp_name)
+            os.unlink(tmp_name)
         return data.rstrip("\r\n")
 
     @property

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -46,7 +46,6 @@ def test_saved_data_is_reused_if_available(aocd_data_dir, requests_mock):
     assert data == "saved data for year 2018 day 1"
     assert not mock.called
 
-
 def test_server_error(requests_mock, caplog):
     mock = requests_mock.get(
         url="https://adventofcode.com/2101/day/1/input",
@@ -140,6 +139,9 @@ def test_race_on_download_data(mocker, aocd_data_dir, requests_mock):
         return ret
     mocker.patch('os.open', side_effect=logging_os_open)
 
+    # This doesn't use unittest.mock_open because we actually do want the faked object to be functional.
+    # We don't want fake results or to assert things are called in a certain order; we just want the
+    # write operation to be slow.
     def generate_open(real_open):
         def open_impl(file, *args, **kwargs):
             res = real_open(file, *args, **kwargs)

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -155,11 +155,14 @@ def test_race_on_download_data(mocker, aocd_data_dir, requests_mock):
             return res
         return open_impl
     mocker.patch('io.open', side_effect=generate_open(io.open))
-    mocker.patch('__builtin__.open' if PY2 else 'builtins.open', create=True, side_effect=generate_open(open))
+    mocker.patch('__builtin__.open' if PY2 else 'builtins.open', side_effect=generate_open(open))
 
     t = threading.Thread(target=aocd.get_data, kwargs={'year': 2018, 'day': 1})
     t.start()
-    open_evt.wait()
+    # This doesn't quite work on python 2 because the io.open patch doesn't seem to work.
+    # We still get coverage by making sure the right thing happens in py3, though.
+    if not PY2:
+        open_evt.wait()
     mocker.stopall()
     data = aocd.get_data(year=2018, day=1)
     write_evt.set()

--- a/tests/test_get_data.py
+++ b/tests/test_get_data.py
@@ -3,8 +3,8 @@ import logging
 import pytest
 import io
 import os
+import sys
 import threading
-from six import PY2
 
 import aocd
 from aocd.exceptions import AocdError
@@ -157,6 +157,7 @@ def test_race_on_download_data(mocker, aocd_data_dir, requests_mock):
             return res
         return open_impl
     mocker.patch('io.open', side_effect=generate_open(io.open))
+    PY2 = sys.version_info.major < 3
     mocker.patch('__builtin__.open' if PY2 else 'builtins.open', side_effect=generate_open(open))
 
     t = threading.Thread(target=aocd.get_data, kwargs={'year': 2018, 'day': 1})

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -361,3 +361,19 @@ def test_user_from_unknown_id(aocd_config_dir):
     cache.write_text('{"github.testuser.123456":"testtoken"}')
     with pytest.raises(UnknownUserError("User with id 'blah' is not known")):
         User.from_id("blah")
+
+def test_example_data_cache(aocd_data_dir, requests_mock):
+    mock = requests_mock.get(
+        url="https://adventofcode.com/2018/day/1",
+        text="<pre><code>1\n2\n3\n</code></pre><pre><code>annotated</code></pre>",
+    )
+    cached = aocd_data_dir / "testauth.testuser.000/2018_01_example_input.txt"
+    assert not cached.exists()
+    puzzle = Puzzle(day=1, year=2018)
+    assert puzzle.example_data == "1\n2\n3"
+    assert mock.called
+    assert cached.read_text() == "1\n2\n3\n"
+    requests_mock.reset()
+    assert puzzle.example_data == "1\n2\n3"
+    assert not mock.called
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import platform
 import sys
 import pytest
 from aocd.exceptions import DeadTokenError
+from aocd.utils import atomic_write_file
 from aocd.utils import blocker
 from aocd.utils import get_owner
 from freezegun import freeze_time
@@ -62,3 +63,12 @@ def test_get_owner_google(requests_mock):
     )
     owner = get_owner("...")
     assert owner == "google.wim.1"
+
+def test_atomic_write_file(aocd_data_dir):
+    target = aocd_data_dir / "foo/bar/baz.txt"
+    # Python 2.7 requires inputs to os.path.expanduser to be strings, not PosixPath (which is missing startswith)
+    atomic_write_file(str(target), "9cdfc92d-c0d2-4af7-87e2-06e49619b30e")
+    assert target.read_text() == "9cdfc92d-c0d2-4af7-87e2-06e49619b30e"
+    atomic_write_file(str(target), "91b80012-3cee-4cbe-8242-460a081c9d73")
+    # It's actually OS-dependent which file wins. But we want to make sure we have coverage
+    # of the unhappy path.


### PR DESCRIPTION
Use an atomic rename instead of writing directly to the cached data files. This solves the race that happens if another instance of aocd sees the file existing.

Add a test that exercises this path by pretending write() is very slow. This test fails without the changes.