### PR TITLE
Provide type annotations for the public API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,29 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  typesafety:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install --upgrade pip
+          # Tell setuptools to *not* create a PEP 660 import hook and to use
+          # symlinks instead, so that pyright can still find the package. See
+          # https://microsoft.github.io/pyright/#/import-resolution?id=editable-installs
+          pip install --editable . --config-settings editable_mode=strict
+
+      - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
+
+      - uses: jakebailey/pyright-action@v1
+        with:
+          ignore-external: true
+          verify-types: "aocd"

--- a/aocd/__init__.py
+++ b/aocd/__init__.py
@@ -1,4 +1,5 @@
 import sys
+import typing as t
 from functools import partial
 
 from . import _ipykernel
@@ -11,13 +12,34 @@ from . import models
 from . import post
 from . import runner
 from . import utils
+from . import types
 from .exceptions import AocdError
 from .get import get_data
 from .get import get_day_and_year
 from .post import submit as _impartial_submit
 
+__all__ = [
+    "_ipykernel",
+    "cli",
+    "cookies",
+    "data",
+    "examples",
+    "exceptions",
+    "get",
+    "models",
+    "post",
+    "runner",
+    "submit",
+    "types",
+    "utils",
+]
 
-def __getattr__(name):
+if t.TYPE_CHECKING:
+    data: str
+    submit = _impartial_submit
+
+
+def __getattr__(name: str) -> t.Any:
     if name == "data":
         day, year = get_day_and_year()
         return get_data(day=day, year=year)

--- a/aocd/cli.py
+++ b/aocd/cli.py
@@ -13,7 +13,7 @@ from .utils import AOC_TZ
 from .utils import get_plugins
 
 
-def main():
+def main() -> None:
     """Get your puzzle input data, caching it if necessary, and print it on stdout."""
     aoc_now = datetime.datetime.now(tz=AOC_TZ)
     days = range(1, 26)

--- a/aocd/cookies.py
+++ b/aocd/cookies.py
@@ -12,10 +12,10 @@ from .utils import colored
 from .utils import get_owner
 
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def get_working_tokens():
+def get_working_tokens() -> dict[str, str]:
     """Check browser cookie storage for session tokens from .adventofcode.com domain."""
     log.debug("checking for installation of browser-cookie3 package")
     try:
@@ -66,7 +66,7 @@ def get_working_tokens():
     return result
 
 
-def scrape_session_tokens():
+def scrape_session_tokens() -> None:
     """Scrape AoC session tokens from your browser's cookie storage."""
     aocd_token_path = AOCD_CONFIG_DIR / "token"
     aocd_tokens_path = AOCD_CONFIG_DIR / "tokens.json"

--- a/aocd/get.py
+++ b/aocd/get.py
@@ -1,8 +1,11 @@
+from __future__ import annotations
+
 import datetime
 import os
 import re
 import traceback
-from logging import getLogger
+import typing as t
+from logging import Logger, getLogger
 
 from ._ipykernel import get_ipynb_path
 from .exceptions import AocdError
@@ -14,10 +17,15 @@ from .utils import AOC_TZ
 from .utils import blocker
 
 
-log = getLogger(__name__)
+log: Logger = getLogger(__name__)
 
 
-def get_data(session=None, day=None, year=None, block=False):
+def get_data(
+    session: str | None = None,
+    day: int | None = None,
+    year: int | None = None,
+    block: bool = False,
+) -> str:
     """
     Get data for day (1-25) and year (2015+).
     User's session cookie (str) is needed - puzzle inputs differ by user.
@@ -45,7 +53,7 @@ def get_data(session=None, day=None, year=None, block=False):
         return puzzle.input_data
 
 
-def most_recent_year():
+def most_recent_year() -> int:
     """
     This year, if it's December.
     The most recent year, otherwise.
@@ -60,7 +68,7 @@ def most_recent_year():
     return year
 
 
-def current_day():
+def current_day() -> int:
     """
     Most recent day, if it's during the Advent of Code. Happy Holidays!
     Day 1 is assumed, otherwise.
@@ -73,7 +81,7 @@ def current_day():
     return day
 
 
-def get_day_and_year():
+def get_day_and_year() -> tuple[int, int | None]:
     """
     Returns tuple (day, year).
 

--- a/aocd/post.py
+++ b/aocd/post.py
@@ -1,18 +1,32 @@
+from __future__ import annotations
+
 import logging
+import typing as t
 
 from .get import current_day
 from .get import most_recent_year
 from .models import default_user
 from .models import Puzzle
 from .models import User
+from .types import AnswerValue
+from .types import PuzzlePart
+
+if t.TYPE_CHECKING:
+    from urllib3 import BaseHTTPResponse
 
 
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
 def submit(
-    answer, part=None, day=None, year=None, session=None, reopen=True, quiet=False
-):
+    answer: AnswerValue,
+    part: PuzzlePart | None = None,
+    day: int | None = None,
+    year: int | None = None,
+    session: str | None = None,
+    reopen: bool = True,
+    quiet: bool = False,
+) -> BaseHTTPResponse | None:
     """
     Submit your answer to adventofcode.com, and print the response to the terminal.
     The only required argument is `answer`, all others can usually be introspected

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import itertools
 import logging
@@ -5,9 +7,11 @@ import os
 import sys
 import tempfile
 import time
+import typing as t
 from argparse import ArgumentParser
 from datetime import datetime
 from functools import partial
+from importlib.metadata import EntryPoint
 from pathlib import Path
 
 import pebble.concurrent
@@ -27,10 +31,10 @@ from .utils import get_plugins
 
 
 DEFAULT_TIMEOUT = 60
-log = logging.getLogger(__name__)
+log: logging.Logger = logging.getLogger(__name__)
 
 
-def main():
+def main() -> t.NoReturn:
     """
     Run user solver(s) against their inputs and render the results. Can use multiple
     tokens to validate your code against multiple input datas.
@@ -199,7 +203,14 @@ def _process_wrapper(f, capture=False, **kwargs):
         return f(**kwargs)
 
 
-def run_with_timeout(entry_point, timeout, progress, dt=0.1, capture=False, **kwargs):
+def run_with_timeout(
+    entry_point: EntryPoint,
+    timeout: float,
+    progress: str | None,
+    dt: float = 0.1,
+    capture: bool = False,
+    **kwargs: t.Any,
+) -> tuple[str, str, float, str]:
     """
     Execute a user solve, and display a progress spinner as it's running. Kill it if
     the runtime exceeds `timeout` seconds.
@@ -234,7 +245,7 @@ def run_with_timeout(entry_point, timeout, progress, dt=0.1, capture=False, **kw
     return a, b, walltime, error
 
 
-def format_time(t, timeout=DEFAULT_TIMEOUT):
+def format_time(t: float, timeout: float = DEFAULT_TIMEOUT) -> str:
     """
     Used for rendering the puzzle solve time in color:
     - green, if you're under a quarter of the timeout (15s default)
@@ -252,8 +263,14 @@ def format_time(t, timeout=DEFAULT_TIMEOUT):
 
 
 def run_one(
-    year, day, data, entry_point, timeout=DEFAULT_TIMEOUT, progress=None, capture=False
-):
+    year: int,
+    day: int,
+    data: str,
+    entry_point: EntryPoint,
+    timeout: float = DEFAULT_TIMEOUT,
+    progress: str | None = None,
+    capture: bool = False,
+) -> tuple[str, str, float, str]:
     """
     Creates a temporary dir and change directory into it (restores cwd on exit).
     Lays down puzzle input in a file called "input.txt" in this directory - user code
@@ -293,16 +310,16 @@ def run_one(
 
 
 def run_for(
-    plugs,
-    years,
-    days,
-    datasets,
-    example=False,
-    timeout=DEFAULT_TIMEOUT,
-    autosubmit=True,
-    reopen=False,
-    capture=False,
-):
+    plugs: t.Collection[str],
+    years: t.Iterable[int],
+    days: t.Iterable[int],
+    datasets: t.Mapping[str, str],
+    example: bool = False,
+    timeout: float = DEFAULT_TIMEOUT,
+    autosubmit: bool = True,
+    reopen: bool = False,
+    capture: bool = False,
+) -> int:
     """
     Run with multiple users, multiple datasets, multiple years/days, and render the results.
     """

--- a/aocd/types.py
+++ b/aocd/types.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from numbers import Number
+from typing import Literal, TypedDict, Union
+
+AnswerValue = Union[str, Number]
+"""The answer to a puzzle, either a string or a number. Numbers are coerced to a string"""
+PuzzlePart = Literal["a", "b"]
+"""The part of a given puzzle, a or b"""
+
+
+class PuzzleStats(TypedDict):
+    """Your personal stats for a given puzzle
+
+    See https://adventofcode.com/<year>/leaderboard/self when logged in.
+    """
+
+    time: timedelta
+    rank: int
+    score: int
+
+
+class Submission(TypedDict):
+    """Record of a previous submission made for a given puzzle
+
+    Only applies to answers submitted with aocd.
+    """
+
+    part: PuzzlePart
+    value: str
+    when: str
+    message: str

--- a/aocd/utils.py
+++ b/aocd/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import logging
 import os
@@ -5,12 +7,14 @@ import platform
 import shutil
 import sys
 import time
+import typing as t
 from collections import deque
 from datetime import datetime
 from functools import cache
 from importlib.metadata import entry_points
 from importlib.metadata import version
 from itertools import cycle
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from zoneinfo import ZoneInfo
 
@@ -19,8 +23,16 @@ import urllib3
 
 from .exceptions import DeadTokenError
 
+if sys.version_info >= (3, 10):
+    # Python 3.10+
+    from importlib.metadata import EntryPoints as _EntryPointsType
+else:
+    # Python 3.9
+    from importlib.metadata import EntryPoint
 
-log = logging.getLogger(__name__)
+    _EntryPointsType = list[EntryPoint]
+
+log: logging.Logger = logging.getLogger(__name__)
 AOC_TZ = ZoneInfo("America/New_York")
 _v = version("advent-of-code-data")
 USER_AGENT = f"github.com/wimglenn/advent-of-code-data v{_v} by hey@wimglenn.com"
@@ -31,7 +43,10 @@ class HttpClient:
     # so that we can put in user agent header, rate-limit, etc.
     # aocd users should not need to use this class directly.
 
-    def __init__(self):
+    pool_manager: urllib3.PoolManager
+    req_count: dict[t.Literal["GET", "POST"], int]
+
+    def __init__(self) -> None:
         
         proxy_url = os.environ.get('http_proxy') or os.environ.get('https_proxy')
         if proxy_url:
@@ -62,7 +77,9 @@ class HttpClient:
             self._cooloff *= 2  # double it for repeat offenders
         self._history.append(now)
 
-    def get(self, url, token=None, redirect=True):
+    def get(
+        self, url: str, token: str | None = None, redirect: bool = True
+    ) -> urllib3.BaseHTTPResponse:
         # getting user inputs, puzzle prose, etc
         if token is None:
             headers = self.pool_manager.headers
@@ -73,7 +90,9 @@ class HttpClient:
         self.req_count["GET"] += 1
         return resp
 
-    def post(self, url, token, fields):
+    def post(
+        self, url: str, token: str, fields: t.Mapping[str, str]
+    ) -> urllib3.BaseHTTPResponse:
         # submitting answers
         headers = self.pool_manager.headers | {"Cookie": f"session={token}"}
         self._limiter()
@@ -88,14 +107,19 @@ class HttpClient:
         return resp
 
 
-http = HttpClient()
+http: HttpClient = HttpClient()
 
 
 def _ensure_intermediate_dirs(path):
     path.expanduser().parent.mkdir(parents=True, exist_ok=True)
 
 
-def blocker(quiet=False, dt=0.1, datefmt=None, until=None):
+def blocker(
+    quiet: bool = False,
+    dt: float = 0.1,
+    datefmt: str | None = None,
+    until: tuple[int, int] | None = None,
+) -> None:
     """
     This function just blocks until the next puzzle unlocks.
     Pass `quiet=True` to disable the spinner etc.
@@ -142,7 +166,7 @@ def blocker(quiet=False, dt=0.1, datefmt=None, until=None):
         sys.stdout.flush()
 
 
-def get_owner(token):
+def get_owner(token: str) -> str:
     """
     Find owner of the token.
     Raises `DeadTokenError` if the token is expired/invalid.
@@ -179,7 +203,7 @@ def get_owner(token):
     return result
 
 
-def atomic_write_file(path, contents_str):
+def atomic_write_file(path: Path, contents_str: str) -> None:
     """
     Atomically write a string to a file by writing it to a temporary file, and then
     renaming it to the final destination name. This solves a race condition where existence
@@ -209,12 +233,15 @@ def _cli_guess(choice, choices):
     return result
 
 
-_ansi_colors = ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]
+_ANSIColor = t.Literal[
+    "black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"
+]
+_ansi_colors = t.get_args(_ANSIColor)
 if platform.system() == "Windows":
     os.system("color")  # hack - makes ANSI colors work in the windows cmd window
 
 
-def colored(txt, color):
+def colored(txt: str, color: _ANSIColor | None) -> str:
     if color is None:
         return txt
     code = _ansi_colors.index(color.casefold())
@@ -222,7 +249,7 @@ def colored(txt, color):
     return f"\x1b[{code + 30}m{txt}{reset}"
 
 
-def get_plugins(group="adventofcode.user"):
+def get_plugins(group: str = "adventofcode.user") -> _EntryPointsType:
     """
     Currently installed plugins for user solves.
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,10 @@ aoce = "aocd.examples:main"
 [tool.setuptools]
 packages = ["aocd"]
 
+[tool.setuptools.package-data]
+aocd = ["py.typed"]
+
+
 [project.entry-points]
 "adventofcode.user" = {}  # for user solvers
 "adventofcode.examples" = {}  # for example-parser implementations
@@ -62,3 +66,8 @@ addopts = """
   --cov-report=html --cov-report=term-missing:skip-covered"""
 xfail_strict = true
 markers = "answer_not_cached"
+
+[tool.coverage.report]
+exclude_also = [
+  "if t\\.TYPE_CHECKING:"
+]


### PR DESCRIPTION
The package now includes a PEP 561 `py.typed` flag file to let type
checkers know that this package provides type annotations.

The annotations provide full coverage for all public functions and
classes in the aocd package, with the library reaching 100% coverage as
per `pyright --ignoreexternal --verifytypes`.

A few notes on this PR:

- I tried to follow the [current best practices for type annotations](https://typing.readthedocs.io/en/latest/source/best_practices.html) as much as possible. This includes using `from __future__ import annotations` so the newer but much more readable `A | B` union syntax can be used and have the project still work on Python version 3.9. The exception are the type aliases in `aocd.types`; Python 3.9 has no `typing.TypeAlias` and you can't use `|` syntax in a type alias assignment in 3.9 (it's not an annotation). The first issue could be solved by adding a dependency on the `typing_extensions` library, but that seems overkill for one missing `typing` feature.

- The PR is limited to the public API members _only_. All private names are left untouched. The goal was to provide consumers of aocd with type annotations, not to validate the types used within aocd itself. Contrast this with #123 which tries to provide full typing coverage of the whole codebase.

- I re-introduced the `__all__` list in `aocd/__init__.py` because that's what type checkers use to determine what is public more than anything else. Without this list, none of the imports in `__init__.py` would be seen as exported. I made sure to only export what was exported before.

- A new `aocd.types` module holds public type aliases and `TypedDict` objects for types that I think consumers of `aocd` might find useful; e.g. a consumer might want to store a returned `PuzzleStats` value, and a 3rd-party library might want to expose a method that passes through a `PuzzlePart` and `AnswerValue` argument to `aocd.submit()`. Plus, these provide inline documentation in IDEs that make use of type information (e.g. PyCharm or Visual Studio Code with the Pylance extension).

- The `aocd.examples.Page` dataclass and `aocd.examples.Example` named tuple  already used type annotations for their fields, but these did not properly annotate the optional fields (those that can be `None` as well as their intended type). Changing these to `... | None` means their API has now changed. I don't think this is a big deal, it was really a bug and so I doubt this needs a deprecation warning.

- A second commit extends the Github workflow to validate that the public API keeps the 100% coverage. I recommend adding a [`pre-commit`configuration](https://pre-commit.com/) that checks for this locally on every commit. See https://github.com/RobertCraigie/pyright-python#pre-commit for what that looks like.

Resolves #78 