### PR TITLE
Add get_data as an export

### DIFF
--- a/aocd/__init__.py
+++ b/aocd/__init__.py
@@ -26,6 +26,7 @@ __all__ = [
     "examples",
     "exceptions",
     "get",
+    "get_data",
     "models",
     "post",
     "runner",


### PR DESCRIPTION
`aocd.get_data()` is used in the documentation so it must be part of the exported API.

I use `aocd.get_data()` in my notebooks but type checkers would complain about
the use of a non-exported name at this point.
