### PR TITLE
aocd.extra attr

### DIFF
--- a/aocd/__init__.py
+++ b/aocd/__init__.py
@@ -1,3 +1,5 @@
+import os
+import json
 import sys
 import typing as t
 from functools import partial
@@ -26,6 +28,7 @@ __all__ = [
     "data",
     "examples",
     "exceptions",
+    "extra",
     "get",
     "get_data",
     "models",
@@ -39,6 +42,7 @@ __all__ = [
 
 if t.TYPE_CHECKING:
     data: str
+    extra: dict[str, t.Any]
     puzzle: models.Puzzle
     submit = _impartial_submit
 
@@ -50,6 +54,8 @@ def __getattr__(name: str) -> t.Any:
     if name == "puzzle":
         day, year = get_day_and_year()
         return get_puzzle(day=day, year=year)
+    if name == "extra":
+        return json.loads(os.environ.get("AOCD_EXTRA", "{}"))
     if name == "submit":
         try:
             day, year = get_day_and_year()

--- a/aocd/examples.py
+++ b/aocd/examples.py
@@ -121,13 +121,13 @@ class Example(NamedTuple):
 
     Sometimes examples in the prose need some extra context, such as a fewer
     number of iterations to be used when working with the test data. This may
-    be returned as some human-readable string in `example.extra`
+    be returned as key/val context in `example.extra`.
     """
 
     input_data: str
     answer_a: str | None = None
     answer_b: str | None = None
-    extra: str | None = None
+    extra: dict[str, t.Any] | None = None
 
     @property
     def answers(self) -> tuple[str | None, str | None]:

--- a/aocd/runner.py
+++ b/aocd/runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import itertools
+import json
 import logging
 import os
 import sys
@@ -30,7 +31,7 @@ from .utils import get_plugins
 # every problem has a solution that completes in at most 15 seconds on ten-year-old hardware
 
 
-DEFAULT_TIMEOUT = 60
+DEFAULT_TIMEOUT: float = 60.
 log: logging.Logger = logging.getLogger(__name__)
 
 
@@ -346,6 +347,9 @@ def run_for(
         for dataset in datas:
             if example:
                 data = examples[dataset].input_data
+                extra = examples[dataset].extra
+                if extra:
+                    os.environ[f"AOCD_EXTRA"] = json.dumps(extra)
             else:
                 token = datasets[dataset]
                 os.environ["AOC_SESSION"] = token
@@ -363,6 +367,7 @@ def run_for(
                 progress=progress,
                 capture=capture,
             )
+            os.environ.pop(f"AOCD_EXTRA", None)
             runtime = format_time(walltime, timeout)
             line = "   ".join([runtime, progress])
             if error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "advent-of-code-data"
-version = "2.0.4"
+version = "2.1.0"
 description = "Get your puzzle data with a single import"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -20,7 +20,7 @@ dependencies = [
     "pebble",
     "urllib3",
     'tzdata ; platform_system == "Windows"',
-    "aocd-example-parser >= 2023.2",
+    "aocd-example-parser >= 2023.12.21",
 ]
 
 [[project.authors]]

--- a/tests/test_aocd.py
+++ b/tests/test_aocd.py
@@ -63,3 +63,9 @@ def test_import_puzzle(mocker):
     assert puzzle.year == 2023
     assert puzzle.day == 21
     assert puzzle.input_data == "test puzzle"
+
+
+def test_extra_context(monkeypatch):
+    monkeypatch.setenv("AOCD_EXTRA", '{"k": "v"}')
+    from aocd import extra
+    assert extra["k"] == "v"


### PR DESCRIPTION
Make extra context for example data more machine-readable.

When executing solves using [example datas](https://github.com/wimglenn/aocd-example-parser/), the runner will export `AOCD_EXTRA` var with any extra example context (JSON serialized k/v).