### PR TITLE
Fix REPL detection for Python 3.13

### DIFF
--- a/aocd/get.py
+++ b/aocd/get.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import os
 import re
+import sys
 import traceback
 from logging import getLogger
 from logging import Logger
@@ -174,9 +175,7 @@ def get_day_and_year() -> tuple[int, int | None]:
                 return day, year
         log.debug("skipping frame %s", filename)
     else:
-        import __main__
-
-        if getattr(__main__, "__file__", "<input>") == "<input>":
+        if hasattr(sys, "ps1"):
             log.debug("running within REPL")
             day = current_day()
             year = most_recent_year()

--- a/tests/test_aocd.py
+++ b/tests/test_aocd.py
@@ -42,7 +42,7 @@ def test_submit_doesnt_bind_day_and_year_when_introspection_failed(mocker):
 
 def test_data_in_interactive_mode(monkeypatch, mocker, freezer):
     freezer.move_to("2017-12-10 12:00:00Z")
-    monkeypatch.delattr("__main__.__file__")
+    monkeypatch.setattr("sys.ps1", ">>>>> ", raising=False)
     mock = mocker.patch("aocd.get_data", return_value="repl data")
     data = aocd.data
     mock.assert_called_once_with(day=10, year=2017)


### PR DESCRIPTION
Checking for `__main__.__file__` stops working after Python 3.12.

Switch to checking for [`sys.ps1`](https://docs.python.org/3/library/sys.html#sys.ps1) as a "am I in the REPL" check.